### PR TITLE
Update README with Supabase Auth0 provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ In the `src/index.jsx` file, configure these credentials by replacing the placeh
 ##### **Step 3.2: Setup Supabase Credentials**  
 
 1. Sign up or log in to [Supabase](https://supabase.com/).  
-2. Create a new project in the Supabase dashboard.  
-3. Navigate to **Project Settings** → **API** and copy the following credentials:  
+2. Create a new project in the Supabase dashboard.
+3. Navigate to **Authentication** → **Providers** and enable Auth0.
+4. Navigate to **Project Settings** → **API** and copy the following credentials:  
    - **Supabase URL**  
    - **Anon Public Key**  
 


### PR DESCRIPTION
This commit resolves the `400 Bad Request` error by ensuring the `Auth0` provider is correctly configured in `Supabase`, allowing for successful JWT token exchange.